### PR TITLE
feat: Reduce gap space in footer carousel

### DIFF
--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -1,17 +1,17 @@
 <div
   class="flex flex-col font-mono_lite w-full fixed bottom-0 opacity-500 overflow-hidden text-gray-200 text-xs uppercase z-30"
 >
-<div class="background-div min-h-4"></div>
+  <div class="background-div min-h-4"></div>
   <div class="bg-black max-h-[70%] inline-flex flex-nowrap">
     <ul
-      class="hover:pause flex items-end justify-center md:justify-start [&_li]:mx-8 py-2 animate-infinite-scroll no-scroll whitespace-nowrap"
+      class="hover:pause flex items-end justify-center md:justify-start [&_li]:mx-2 py-2 animate-infinite-scroll no-scroll whitespace-nowrap"
     >
       @for (item of datasetEntries; track $index) {
       <li>{{ item[0] }}:{{ item[1] }}</li>
       }
     </ul>
     <ul
-      class="flex items-center z-50 justify-center md:justify-start [&_li]:mx-8 py-2 animate-infinite-scroll no-scroll whitespace-nowrap"
+      class="flex items-center z-50 justify-center md:justify-start [&_li]:mx-2 py-2 animate-infinite-scroll no-scroll whitespace-nowrap"
       aria-hidden="true"
     >
       @for (item of datasetEntries; track $index) {

--- a/src/app/components/footer/footer.component.ts
+++ b/src/app/components/footer/footer.component.ts
@@ -5,22 +5,24 @@ export interface DatasetInfo {
   [key: string]: string | number;
 }
 @Component({
-    selector: "app-footer",
-    imports: [CommonModule],
-    templateUrl: "./footer.component.html",
-    styleUrl: "./footer.component.css"
+  selector: "app-footer",
+  imports: [CommonModule],
+  templateUrl: "./footer.component.html",
+  styleUrl: "./footer.component.css",
 })
 export class FooterComponent {
   datasetInfo: DatasetInfo = {
     badger: 347,
     buzzard: 63,
     cat: 10,
-    "coordinates of camera 1.0": "43°10'19.2\"N 12°23'53.2\"E",
-    "coordinates of camera 2.0": "43°10'26.3\"N 12°23'53.4\"E",
-    "coordinates of camera 3.0": "43°10'19.0\"N 12°23'49.6\"E",
-    "coordinates of camera 4.0": "43°10'29.6\"N 12°23'54.5\"E",
-    "coordinates of camera 6.0": "43°10'26.2\"N 12°23'52.9\"E",
-    "coordinates of camera 7.0": "43°10'29.4\"N 12°23'44.2\"E",
+    "camera 1": "43°10'19.2\"N 12°23'53.2\"E (DESTROYED BY EXCAVATOR)",
+    "camera 2":
+      "43°10'26.3\"N 12°23'53.4\"E (OVERWHELMED BY THE DRAINAGE CANAL)",
+    "camera 3": "43°10'19.0\"N 12°23'49.6\"E",
+    "camera 4": "43°10'29.6\"N 12°23'54.5\"E",
+    "camera 5": "(STOLEN)",
+    "camera 6": "43°10'26.2\"N 12°23'52.9\"E",
+    "camera 7": "43°10'29.4\"N 12°23'44.2\"E",
     deer: 928,
     fox: 2633,
     hare: 283,


### PR DESCRIPTION
Reduced gap space in footer carousel (as proposed by @ilbarlafus) and slightly modified some keys (e.g `coordinates of camera 1.0` to `camera 1`)